### PR TITLE
Update ChannelList.jsx

### DIFF
--- a/src/components/ChannelList.jsx
+++ b/src/components/ChannelList.jsx
@@ -56,10 +56,10 @@ class ChannelList extends React.Component {
 
     var channelNodes = _(this.props.channels)
       .keys()
-      .map((k)=> {
+      .map((k, i)=> {
         let channel = this.props.channels[k];
         return (
-          <Channel channel={channel} />
+          <Channel channel={channel} key={i}/>
         );
       })
       .value();


### PR DESCRIPTION
By adding a 'key' property to the properties of each Channel, the respective warning will go away. In this case, the key could either be the index or the key, but wanted to be consistent with the other PR.
