### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Code used for a Pluralsight.com course about a real-time React stack with Flux, 
 
 Go check out the course at https://app.pluralsight.com/library/courses/build-isomorphic-app-react-flux-webpack-firebase!
 
-#Get up and running
+# Get up and running
 
 * From the command line, clone this repo: `git clone https://github.com/hendrikswan/react-stack && cd react-stack`
 * Run `npm install` to install all the modules (pegged to specific NPM modules to ensure that it works for you)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
